### PR TITLE
Remove builtin modules from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,17 +4,12 @@
   "description": "",
   "main": "bot.js",
   "dependencies": {
-    "crypto": "^0.0.3",
-    "events": "^1.1.1",
-    "fs": "^0.0.2",
-    "https": "^1.0.0",
     "long": "^3.1.0",
     "protobufjs": "^5.0.1",
     "q": "^1.4.1",
     "readline-sync": "^1.4.4",
     "steam": "^1.4.0",
-    "steamid": "^1.1.0",
-    "process": "^0.11.5"
+    "steamid": "^1.1.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Unless you are trying to deploy on a more than ancient version of node all of those packages are core modules, you don't need to install them using npm.

https://nodejs.org/api/